### PR TITLE
Enable real-time Docent ingestion in custom_model

### DIFF
--- a/finance_agent/custom_model.py
+++ b/finance_agent/custom_model.py
@@ -40,7 +40,7 @@ async def get_custom_model(
         prompt = INSTRUCTIONS_PROMPT.format(question=test_input)
 
         agent = get_agent(params, llm=llm)
-        result = await agent.run([TextInput(text=prompt)], question_id=question_id, run_id=run_id)
+        result = await agent.run([TextInput(text=prompt)], question_id=question_id, run_id=run_id, docent_ingest=True)
 
         if not result.success and result.final_error:
             print(f"\nFAIL {question_id} failed: [{result.final_error.type}] {result.final_error.message}\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "dotenv>=0.9.9",
     "requests>=2.32.5",
     "sec-api>=1.0.32",
-    "model-library==0.1.19",
+    "model-library==0.1.23",
     "tavily-python>=0.7.23",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -146,7 +146,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.86.0"
+version = "0.97.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -158,9 +158,15 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/7a/8b390dc47945d3169875d342847431e5f7d5fa716b2e37494d57cfc1db10/anthropic-0.86.0.tar.gz", hash = "sha256:60023a7e879aa4fbb1fed99d487fe407b2ebf6569603e5047cfe304cebdaa0e5", size = 583820, upload-time = "2026-03-18T18:43:08.017Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/93/f66ea8bfe39f2e6bb9da8e27fa5457ad2520e8f7612dfc547b17fad55c4d/anthropic-0.97.0.tar.gz", hash = "sha256:021e79fd8e21e90ad94dc5ba2bbbd8b1599f424f5b1fab6c06204009cab764be", size = 669502, upload-time = "2026-04-23T20:52:34.445Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/5f/67db29c6e5d16c8c9c4652d3efb934d89cb750cad201539141781d8eae14/anthropic-0.86.0-py3-none-any.whl", hash = "sha256:9d2bbd339446acce98858c5627d33056efe01f70435b22b63546fe7edae0cd57", size = 469400, upload-time = "2026-03-18T18:43:06.526Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b6/8e851369fa661ad0fef2ae6266bf3b7d52b78ccf011720058f4adaca59e2/anthropic-0.97.0-py3-none-any.whl", hash = "sha256:8a1a472dfabcfc0c52ff6a3eecf724ac7e07107a2f6e2367be55ceb42f5d5613", size = 662126, upload-time = "2026-04-23T20:52:32.377Z" },
+]
+
+[package.optional-dependencies]
+aiohttp = [
+    { name = "aiohttp" },
+    { name = "httpx-aiohttp" },
 ]
 
 [[package]]
@@ -501,7 +507,7 @@ requires-dist = [
     { name = "backoff", specifier = ">=2.2.1" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "dotenv", specifier = ">=0.9.9" },
-    { name = "model-library", specifier = "==0.1.19" },
+    { name = "model-library", specifier = "==0.1.23" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "sec-api", specifier = ">=1.0.32" },
     { name = "tavily-python", specifier = ">=0.7.23" },
@@ -820,6 +826,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-aiohttp"
+version = "0.1.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/2c/b894861cecf030fb45675ea24aa55b5722e97c602a163d872fca66c5a6d8/httpx_aiohttp-0.1.12.tar.gz", hash = "sha256:81feec51fd82c0ecfa0e9aaf1b1a6c2591260d5e2bcbeb7eb0277a78e610df2c", size = 275945, upload-time = "2025-12-12T10:12:15.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/8d/85c9701e9af72ca132a1783e2a54364a90c6da832304416a30fc11196ab2/httpx_aiohttp-0.1.12-py3-none-any.whl", hash = "sha256:5b0eac39a7f360fa7867a60bcb46bb1024eada9c01cbfecdb54dc1edb3fb7141", size = 6367, upload-time = "2025-12-12T10:12:14.018Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -958,17 +977,17 @@ wheels = [
 
 [[package]]
 name = "model-library"
-version = "0.1.19"
+version = "0.1.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ai21" },
-    { name = "anthropic" },
+    { name = "anthropic", extra = ["aiohttp"] },
     { name = "backoff" },
     { name = "boto3" },
     { name = "google-cloud-storage" },
     { name = "google-genai", extra = ["aiohttp"] },
     { name = "mistralai" },
-    { name = "openai" },
+    { name = "openai", extra = ["aiohttp"] },
     { name = "pillow" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -978,9 +997,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "xai-sdk" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/e8/255208df2135287bc1cdd53b54f857794ca4f3aea438c8e4717daf147051/model_library-0.1.19.tar.gz", hash = "sha256:890f6f63b7766fe3110b0062dda7de5fe00350116f0a8e7aadc1fb720da5f341", size = 372380, upload-time = "2026-03-20T02:19:26.251Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/7d/28e176ee5234d95617748d1515a3c3b4bb818ed51a9ada66c1eab39d56f4/model_library-0.1.23.tar.gz", hash = "sha256:9777443f27ee7294cfa79cb8c4f26ea5f09e3ab1b325324743bcdbdded580171", size = 471062, upload-time = "2026-04-17T22:57:04.201Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c8/ce3512f1b172675c596b3b445b583cbb428ca3f626d18fc423805dd712b4/model_library-0.1.19-py3-none-any.whl", hash = "sha256:39b6209de9a0e4a6512e5912bd143fb4174f0801001b11cc18cdc70da9c35975", size = 173852, upload-time = "2026-03-20T02:19:24.945Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/95/fe077ba4148d133d8bf12440f6977133a92f0188e4d6216b6abab4ceaea1/model_library-0.1.23-py3-none-any.whl", hash = "sha256:41c4427f75ea902c31268d1e9b354cb2cacfa78a432860285077a912a2466ae7", size = 184860, upload-time = "2026-04-17T22:57:02.603Z" },
 ]
 
 [[package]]
@@ -1115,6 +1134,12 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b4/15/203d537e58986b5673e7f232453a2a2f110f22757b15921cbdeea392e520/openai-2.29.0.tar.gz", hash = "sha256:32d09eb2f661b38d3edd7d7e1a2943d1633f572596febe64c0cd370c86d52bec", size = 671128, upload-time = "2026-03-17T17:53:49.599Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/b1/35b6f9c8cf9318e3dbb7146cc82dab4cf61182a8d5406fc9b50864362895/openai-2.29.0-py3-none-any.whl", hash = "sha256:b7c5de513c3286d17c5e29b92c4c98ceaf0d775244ac8159aeb1bddf840eb42a", size = 1141533, upload-time = "2026-03-17T17:53:47.348Z" },
+]
+
+[package.optional-dependencies]
+aiohttp = [
+    { name = "aiohttp" },
+    { name = "httpx-aiohttp" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Wires real-time Docent ingestion into the finance-agent custom model: passes \`docent_ingest=True\` to \`agent.run\` so transcripts stream into Docent as the run executes (grouped under the platform's \`run_id\`).

## Changes
- \`pyproject.toml\`: \`model-library==0.1.19\` → \`0.1.23\` (first PyPI release where \`Agent.run\` accepts the \`docent_ingest\` kwarg).
- \`uv.lock\`: refreshed to pick up new resolutions (\`model-library 0.1.19 → 0.1.23\`, \`anthropic 0.86.0 → 0.97.0\`, \`+httpx-aiohttp 0.1.12\`).
- \`finance_agent/custom_model.py\`: pass \`docent_ingest=True\` on the \`agent.run\` call. \`question_id\` and \`run_id\` were already forwarded from the platform.

## Why
Companion to the benchmarks-side PR (vals-ai/benchmarks#1578) that enables real-time Docent ingestion across custom models. Finance-agent was blocked because its model-library pin predated the \`docent_ingest\` kwarg; bumping unblocks it.

## Notes
- Independent of the in-flight \`oa/docent-ingestion\` branch (Valkyrie route). This is the smallest change to enable the real-time path; the Valkyrie work can land separately.
- Docent failures don't block the run (model-library swallows ingestion errors and warns).

## Test plan
- [ ] \`make install && make style && make typecheck\` pass.
- [ ] On the next finance_agent benchmark run, verify transcripts appear in the Docent collection at \`https://docent.transluce.org/dashboard/{run_id}\`.